### PR TITLE
Working example of WebSocketServer

### DIFF
--- a/Quria/java.js
+++ b/Quria/java.js
@@ -19,16 +19,20 @@ function openAppen(){
     location.href = "androidrfid://primaryid?itemid=" + itemId;
 }
 
-var ws;
+var ip = "localhost";
+var port = "8888";
+var ws = new WebSocket("ws://" + ip + ":" + port);
+ws.onopen = function() {
+  var doSendPing = confirm('connected! Send ping? Otherwise we will send "bla bla".');
+  if (doSendPing) {
+    ws.send('ping');
+  } else {
+    ws.send('bla bla');
+  }
+};
+ws.onmessage = function (event) {
+  if (event.data === 'echo') {
+    alert(event.data);
+  }
+}
 
-$("#connect").click(function(e)
-{
-
-        var ip = $("#address").val();
-        ws = new WebSocket("ws://" + ip);
-        ws.onopen = function()
-        {
-             alert("connected!");
-        };
-
-});

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'org.java-websocket:Java-WebSocket:1.5.1'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/app/src/main/java/com/example/rfid_mobilapp/MainActivity.java
+++ b/app/src/main/java/com/example/rfid_mobilapp/MainActivity.java
@@ -56,13 +56,16 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        try {
-            ServerSocket server = new ServerSocket(8080);
-            Log.d(TAG, "Server has started on localhost.\r\nWaiting for a connection...");
+        //try {
+            //ServerSocket server = new ServerSocket(8080);
+            //Log.d(TAG, "Server has started on localhost.\r\nWaiting for a connection...");
             Thread thread = new Thread(() -> {
+                String host = "localhost";
+                int port = 8888;
                 try  {
-                    Socket client = server.accept();
-                    Log.d(TAG, "A client connected.");
+                    InetSocketAddress listenAddress = new InetSocketAddress(host, port);
+                    SocketServer server = new SocketServer(listenAddress);
+                    server.run();
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -104,9 +107,9 @@ public class MainActivity extends AppCompatActivity {
             doCheckIn = uri.getQueryParameter("doCheckIn");
         }
         chooseLanguage();*/
-        } catch (IOException ioException) {
-            ioException.printStackTrace();
-        }
+        //} catch (IOException ioException) {
+        //    ioException.printStackTrace();
+        //}
     }
 
 

--- a/app/src/main/java/com/example/rfid_mobilapp/SocketServer.java
+++ b/app/src/main/java/com/example/rfid_mobilapp/SocketServer.java
@@ -1,0 +1,62 @@
+package com.example.rfid_mobilapp;
+
+import android.util.Log;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+
+import org.java_websocket.WebSocket;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.server.WebSocketServer;
+
+public class SocketServer extends WebSocketServer {
+
+    public SocketServer(InetSocketAddress address) {
+        super(address);
+    }
+
+    @Override
+    public void onOpen(WebSocket conn, ClientHandshake handshake) {
+        conn.send("Welcome to the server!"); //This method sends a message to the new client
+        broadcast( "new connection: " + handshake.getResourceDescriptor() ); //This method sends a message to all clients connected
+        System.out.println("new connection to " + conn.getRemoteSocketAddress());
+    }
+
+    @Override
+    public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+        System.out.println("closed " + conn.getRemoteSocketAddress() + " with exit code " + code + " additional info: " + reason);
+    }
+
+    @Override
+    public void onMessage(WebSocket conn, String message) {
+        System.out.println("received message from "	+ conn.getRemoteSocketAddress() + ": " + message);
+        if (message.equals("ping")) {
+            // "command" ping received, sending echo.
+            conn.send("echo");
+        }
+    }
+
+    @Override
+    public void onMessage( WebSocket conn, ByteBuffer message ) {
+        System.out.println("received ByteBuffer from "	+ conn.getRemoteSocketAddress());
+    }
+
+    @Override
+    public void onError(WebSocket conn, Exception ex) {
+        System.err.println("an error occurred on connection " + conn.getRemoteSocketAddress()  + ":" + ex);
+    }
+
+    @Override
+    public void onStart() {
+        System.out.println("server started successfully");
+    }
+
+
+    public static void main(String[] args) {
+        String host = "localhost";
+        int port = 8887;
+
+        WebSocketServer server = new SocketServer(new InetSocketAddress(host, port));
+        server.run();
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ buildscript {
         google()
         jcenter()
         mavenCentral()
-
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'


### PR DESCRIPTION
This works for `ws` connections, not `wss`.
So for example using the HTTPS page on github pages wont work.

But if you open the small web client in Chrome as a file, it will work.
If its possible to open the file from the Android Emulator, or a real mobile phone, it would work.

But you can also open the HTML page from your development machine, although you then need to forward the port.
You can do this by using the `adb` tool, which normally is installed through the Android SDK.
It should be located at for example C:\Users\[userName]\AppData\Local\Android\Sdk\platform-tools\
Go to that directory using for example PowerShell or CMD.
run the following command: `.\adb.exe forward tcp:8888 tcp:8888`
That will forward port 8888, which means that if you connect to `ws://localhost:8888` the request will be forwarded to your Android Emulator on the same port.

I have also switched to using this WebSocketServer application: https://github.com/TooTallNate/Java-WebSocket
Your example would have worked in the end, but it would have required much more work to handle messages.
You can still use that if prefer writing everything by yourself.

There is also more high level applications you could have used, like AndroidAsync, but I think that instead contains much more functionality then you need.