### PR TITLE
Recreate a new activity for nfc intents and moved all the nfc methods to it

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.RFIDmobilApp">
+        <activity android:name=".NfcActivity"></activity>
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask">

--- a/app/src/main/java/com/example/rfid_mobilapp/MainActivity.java
+++ b/app/src/main/java/com/example/rfid_mobilapp/MainActivity.java
@@ -26,11 +26,8 @@ public class MainActivity extends AppCompatActivity {
     TextView quriaText;
     Intent serviceIntent;
     Locale myLocale;
-    NfcAdapter mNfcAdapter;
     static String newItemId;
     static String doCheckIn;
-    private static final boolean checkIn = true;
-    private static final boolean checkOut = false;
 
     private SharedPreferences preferences;
     private final String LANG_PREF_KEY = "language";
@@ -41,7 +38,6 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Log.d(TAG, " on create");
-        mNfcAdapter = NfcAdapter.getDefaultAdapter(this);
         onCreateHelper();
     }
 
@@ -76,27 +72,17 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
+        Log.d(TAG, "new intent");
         if (socketServiceSwitch.isChecked()){
-            Log.d(TAG, "new intent");
-            if (doCheckIn != null) {
-                Log.d(TAG, "will do check");
-                if (doCheckIn.equals("false")) {
-                    NfcTagUtil.check(intent, this, checkOut);
-                    Log.d(TAG, "out");
-                } else {
-                    NfcTagUtil.check(intent, this, checkIn);
-                    Log.d(TAG, "in");
-                }
-                doCheckIn = null;
-                newItemId = "";
-            } else if (newItemId != null && !newItemId.isEmpty()) {
-                NfcTagUtil.writeNewItemId(newItemId, intent, this);
-                newItemId = "";
-            } else {
-                NfcTagUtil.getItemId(intent, this);
-            }
+            Log.d(TAG, "is checked");
+            Intent startNfcActivityIntent= new Intent(this, NfcActivity.class);
+            startNfcActivityIntent.putExtra(Intent.EXTRA_INTENT, intent);
+            startNfcActivityIntent.putExtra("newItemId", newItemId);
+            startNfcActivityIntent.putExtra("doCheckIn", doCheckIn);
+            startActivity(startNfcActivityIntent);
         }
-        moveTaskToBack(true);
+        doCheckIn = null;
+        newItemId = "";
     }
 
     public static void setItemId(String itemId) {
@@ -119,7 +105,6 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        NfcTagUtil.enableNFCInForeground(mNfcAdapter, this, getClass());
         Log.d(TAG, "on Resume");
     }
 
@@ -132,7 +117,6 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onPause() {
         super.onPause();
-        NfcTagUtil.disableNFCInForeground(mNfcAdapter, this);
         Log.d(TAG, "on pause");
     }
 

--- a/app/src/main/java/com/example/rfid_mobilapp/NfcActivity.java
+++ b/app/src/main/java/com/example/rfid_mobilapp/NfcActivity.java
@@ -1,0 +1,70 @@
+package com.example.rfid_mobilapp;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.content.Intent;
+import android.nfc.NfcAdapter;
+import android.os.Bundle;
+import android.util.Log;
+
+public class NfcActivity extends AppCompatActivity {
+    private static final String TAG = NfcActivity.class.getSimpleName();
+
+    NfcAdapter mNfcAdapter;
+    static String newItemId;
+    static String doCheckIn;
+    private static final boolean checkIn = true;
+    private static final boolean checkOut = false;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_nfc);
+        mNfcAdapter = NfcAdapter.getDefaultAdapter(this);
+        Intent startIntent= getIntent();
+        Intent tagIntent= startIntent.getParcelableExtra(Intent.EXTRA_INTENT);
+        newItemId= startIntent.getStringExtra("newItemId");
+        doCheckIn= startIntent.getStringExtra("doCheckIn");
+        handleTag(tagIntent);
+    }
+
+
+    private void handleTag(Intent intent){
+        if (doCheckIn != null) {
+            Log.d(TAG, "will do check");
+            if (doCheckIn.equals("false")) {
+                NfcTagUtil.check(intent, this, checkOut);
+                Log.d(TAG, "out");
+            } else {
+                NfcTagUtil.check(intent, this, checkIn);
+                Log.d(TAG, "in");
+            }
+        } else if (newItemId != null && !newItemId.isEmpty()) {
+            NfcTagUtil.writeNewItemId(newItemId, intent, this);
+        } else {
+            NfcTagUtil.getItemId(intent, this);
+        }
+        moveTaskToBack(true);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        NfcTagUtil.enableNFCInForeground(mNfcAdapter, this, getClass());
+        Log.d(TAG, "on Resume");
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        Log.d(TAG, "on onStart");
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        NfcTagUtil.disableNFCInForeground(mNfcAdapter, this);
+        Log.d(TAG, "on pause");
+    }
+
+}

--- a/app/src/main/res/layout/activity_nfc.xml
+++ b/app/src/main/res/layout/activity_nfc.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".NfcActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -5,7 +5,7 @@
     <string name="app_name">RFID mobilApp</string>
 
     <string name="success_write">Lyckades skriva till taggen.</string>
-    <string name="failed_write">Misslyckades skriva till taggen.</string>
+    <string name="failed_write">Att skriva till taggen misslyckades.</string>
     <string name="place_tag">Vänligen placera mobilens yta framför taggen</string>
     <string name="ok">Ok</string>
     <string name="welcome">Välkomna</string>


### PR DESCRIPTION
Now it worked for me to do (check in, out, write itemid and read the tag) from the new activity and no problem with the server and without showing the new activity, but it is good to test it more.
I tried to stop and start server many times without closing the app, then I closed the app and open it again, then I tried to open the app from the notification and also no problem with the server. 
One thing I am working on it now is when I open the app from the workmanager, I go direct to the UI activity and not the Nfc activity.  